### PR TITLE
only find files

### DIFF
--- a/slurp_esri_modules.sh
+++ b/slurp_esri_modules.sh
@@ -8,7 +8,7 @@ rm -rf "serverapi.arcgisonline.com"
 
 echo "processing esri modules"
 cd "$SRCDIR/esri"
-FILES=$(find .)
+FILES=$(find . -type f)
 for f in $FILES
 do
   perl -pi -e "


### PR DESCRIPTION
Thanks, this was really useful!  Here's a small change to restrict find to files and avoid the `Can't do inplace edit: . is not a regular file.` errors.
