### PR TITLE
Faster travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ env:
   global:
     - secure: UEXAYK3f2bGw7YmWsMlpAydto7sYu+qd9sUA6J3qvXH+QEan6fc8Yo831hYfsUe66WW6Oz4vp2BwE/r+gQBjJgqpxyq1N4T/7b6p1x7KUwXms6rM8GZfswfUOdlTkIzlWwXyAsnSCuqUlfuT5lKsHi5yurDBgTMVWcSAdi0BQjc=
     - secure: Ir46Mp7v2T1QLfuVRzZbCQ1NrLj8q8kiVzAgNsNDeuuBZGlOLJSfOeZ4zbOy/FdXe0iUSw/K5eGaSIKyQdoDJiNdXAm3tOWo0TOfwc0VIvWLEABYcLNxFiHVO7Ju+hUJKFwJgmOo39fmsi63gYNDrEw5+naOB5FQZgCkRO8oCg==
+sudo: false
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
Switch to use container-based infrastructure which results in faster start times.

Cache node_modules folder.
