### PR TITLE
Implement map-tools/extentRouter

### DIFF
--- a/_src/app/App.js
+++ b/_src/app/App.js
@@ -23,6 +23,7 @@ define([
 
     'layer-selector',
 
+    'map-tools/extentRouter',
     'map-tools/MapView',
 
     'sherlock/providers/WebAPI',
@@ -54,6 +55,7 @@ define([
 
     LayerSelector,
 
+    extentRouter,
     AGRCMapView,
 
     WebAPI,
@@ -214,6 +216,8 @@ define([
                 map,
                 container: this.mapDiv
             });
+
+            extentRouter(this.mapView);
 
             this.agrcMapView = new AGRCMapView(this.mapView);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,9 @@
       }
     },
     "@agrc/map-tools": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@agrc/map-tools/-/map-tools-2.0.2.tgz",
-      "integrity": "sha512-DMCbY/NUOQ1RVzd8zygAZ4zTjj5gtecTaGr10K+P0aFof521N/J3ohUI8L+TFBAvlA1cYc9GaKb/7V4ZdRPJMQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@agrc/map-tools/-/map-tools-2.1.0.tgz",
+      "integrity": "sha512-5JzBA6HWp7eY2ZN9S6IwAiOAn9UKEGoJzdMG7182Nzb9bZ3Jqa0fXQV+OGjOJ/TZ4s7t1FqhGaX+0FAbrUM4Bg==",
       "requires": {
         "arcgis-js-api": "^4.7.x",
         "spinkit": "1.2.5"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@agrc/dart-board": "2.0.4",
     "@agrc/helpers": "1.0.1",
     "@agrc/layer-selector": "2.0.2",
-    "@agrc/map-tools": "2.0.2",
+    "@agrc/map-tools": "2.1.0",
     "@agrc/sherlock": "2.0.2",
     "arcgis-js-api": "4.7.2",
     "bootstrap": "3.3.6",


### PR DESCRIPTION
Closes #202 

This adds URL parameters to the app that can define x, y, scale or zoom. For example:
```
http://atlas.utah.gov/#x=-12455754&y=4978472&zoom=18
```