### PR TITLE
fix: remove wasm mime type

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -17,7 +17,6 @@
     <system.webServer>
         <staticContent>
             <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="30.00:00:00" />
-            <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
         </staticContent>
         <httpProtocol allowKeepAlive="false" />
     </system.webServer>


### PR DESCRIPTION
adding wasm to the global iis setting caused atlas to crash because it had its own wasm entry. 

In the future if we add mime types specifically to a website we need to do it in this manner.

```xml
<remove fileExtension=".type"/>
<mimeMap fileExtension=".type" mimeType="type/>
```