### PR TITLE
fix: support for relative path deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "atlas",
   "version": "5.0.5",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@agrc/dart-board": "^3.3.0",
     "@agrc/layer-selector": "^4.0.4",


### PR DESCRIPTION
This seems like a useful default.

Ref: https://create-react-app.dev/docs/deployment/#building-for-relative-paths