### PR TITLE
ci: only post release issue notifications on prod deploys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
   notify:
     name: Notifications
     runs-on: ubuntu-latest
+    needs: deploy-prod
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Ref: https://github.com/agrc/release-issue-notifications-action/issues/34